### PR TITLE
Bumped spellcheck version to lastest release 0.30.0

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: rojopolis/spellcheck-github-actions@0.22.1
+    - uses: rojopolis/spellcheck-github-actions@0.30.0
       name: Spellcheck
       with:
         config_path: ".config/.spellcheck.yml"


### PR DESCRIPTION
Hi @pavelskipenes 

Long time no see.

I am _sunsetting_ version 0.22.1 as by the proposed [sunset policy](https://github.com/rojopolis/spellcheck-github-actions/wiki#sunset-policy)

I just updated the action to version 0.30.0, so this PR offers an update to the latest version.

Let me know if you have any issues with the proposed PR and I will do my best to accommodate.

I can recommend [Dependabot](https://github.com/dependabot) for keeping your GitHub actions up to date, alternatively there are [Renovate](https://github.com/marketplace/renovate), if you want a PR proposing a basic configuration for Dependabot, please let me know.

jonasbn
