### PR TITLE
fix-25: fix code quality warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-.vscode
 build
+.cache
+compile_commands.json
 docs/html/*
 docs/latex/*
-compile_commands.json
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
-FROM alpine
+FROM alpine:3.3
 
-RUN apk update
+WORKDIR /app
 
-RUN apk add g++ make
+RUN apk --no-cache add g++ make
 
 COPY . .
 
 RUN make install
 
 CMD ["oven", "100"]
+

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ INCLUDE_DIR := include/
 CONFIG_DIR := .config/
 
 DIALECT := --std=c++17
-CPP_FLAGS := -O0 -g3 -Wall -Wextra -I $(INCLUDE_DIR) -pthread $(DIALECT)
+CPP_FLAGS := -O0 -g3 -Wall -Wextra -I $(INCLUDE_DIR) -pthread $(DIALECT) -static
 CC := g++
 
 SRC_FILES := $(foreach sdir,$(SOURCE_DIR),$(wildcard $(sdir)*.cpp))

--- a/src/core_count.cpp
+++ b/src/core_count.cpp
@@ -17,9 +17,13 @@
 int get_core_count()
 {
     int number_of_cores = 1;
+
+    // Bug: This check only if the compilation is done on a posix complient system.
+    // This check should be run time because users might cross compile the application.
     try
     {
 #ifdef __USE_POSIX2
+        // Bug: In Alpine Linux nproc is not available. Maybe check if the file exists?
         number_of_cores = std::stoi(exec(std::string_view("/usr/bin/nproc")));
 #else
 #warning "Unsupported system. Defaulting to only one core."


### PR DESCRIPTION
- set explicit version on Docker image
- use `--no-cache` inside `apk` command
- use static compilation to avoid crashes when running on non glibc
  systems
- write that there is a bug when looking up how many cores are available
  in the system. However I'm not going to fix it because this relies on
  low level system libraries. To fix this I would need a higher level
  library. To use a higher level library I would need to introduce Cmake
  and some library like Boost. At this point it would be probably easier
  to just rewrite the entire project in Rust in stead.
